### PR TITLE
Add material about containers to CI/CD lesson

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write

--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       checks: write
       contents: write

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -98,12 +98,12 @@ Workflows are usually triggered by events, such as merging to the main branch ha
 
 Nowadays software is often distributed or deployed using containers.
 These containers contain every dependency an application needs and can run anywhere.
-This is especially useful in applications that run as a service on a cloud provider such as Google or Amazon Web Services where it is not known before hand where an application will run.
+This is especially useful for applications that run as a service on a cloud provider such as Google or Amazon Web Services where it is not known beforehand where an application will run.
 These containers are light weight operating system images in which the application is stored including everything it needs.
-To build these container images, CI/CD is extremely useful as it can be automated as explained below in the section explaining pipelines and workflows.
-Running applications in containers tends to enforce decoupling from external dependencies and communicate to external services through well defined and stable interfaces.
+CI/CD is extremely useful for automatically building such container images, as explained below in the section explaining pipelines and workflows.
+Running applications in containers tends to enforce decoupling from external dependencies and communicating to external services through well defined and stable interfaces.
 Building and distributing containers is generally done using [docker](https://www.docker.com) but there are others such as [podman](https://podman.io/)
-
+You can find more information about containers [here](https://book.the-turing-way.org/reproducible-research/renv/renv-containers.html).
 # Pipelines or workflows
 
 > A CI/CD pipeline is an automated process utilized by software development teams to streamline the creation, testing and deployment of applications. -- [gitlab.com][6]
@@ -483,8 +483,7 @@ That's it! Package published!
 
 ## Considerations
 
-CI/CD pipelines are not very suitable if your tests requires a lot of static data.
+CI/CD pipelines are not very suitable if your tests require a lot of static data.
 Running large integration tests inside a CI/CD pipeline is thus not recommended as there is generally limited space and time in CI/CD pipelines.
 Writing small and fast unit tests that run automatically inside CI/CD pipelines rather than large integration tests is recommended.
-It is therefore helpful to practice sotware engineering best practices such as decoupling.
-Decoupling enables testable code.
+It is therefore helpful to practice software engineering best practices such as decoupling, since that will lead to more easily testable code.

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -94,7 +94,7 @@ It also enables the developer to run unit testing in an automated way to discove
 CICD relies on version control.
 Workflows are usually triggered by events, such as merging to the main branch happening on the verson control repository.
 
-# Docker Containers
+# Containers
 
 Nowadays software is often distributed or deployed using containers.
 These containers contain every dependency an application needs and can run anywhere.

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -491,3 +491,7 @@ It is therefore helpful to practice software engineering best practices such as 
 Larger integration tests can still be done in CI/CD as long as they don't require more than a few hundred megabytes of space and can complete within say 30 minutes.
 Check the resource limits your CI/CD infrastructure provider (e.g. github or gitlab) imposes on CI/CD pipelines.
 If you expect your tests to require more time and space than the CI/CD platform of you choice allows, consider alternative approaches such as [blue/green deployments](https://en.wikipedia.org/wiki/Blue%E2%80%93green_deployment).
+Another alternative is to host your own pipeline runners that can be associated with your project on github[9] or gitlab[10].
+
+[9]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners
+[10]: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/v17.5.0/doc/tutorials/create_register_first_runner/index.md

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -104,6 +104,7 @@ CI/CD is extremely useful for automatically building such container images, as e
 Running applications in containers tends to enforce decoupling from external dependencies and communicating to external services through well defined and stable interfaces.
 Building and distributing containers is generally done using [docker](https://www.docker.com) but there are others such as [podman](https://podman.io/)
 You can find more information about containers [here](https://book.the-turing-way.org/reproducible-research/renv/renv-containers.html).
+
 # Pipelines or workflows
 
 > A CI/CD pipeline is an automated process utilized by software development teams to streamline the creation, testing and deployment of applications. -- [gitlab.com][6]
@@ -487,3 +488,6 @@ CI/CD pipelines are not very suitable if your tests require a lot of static data
 Running large integration tests inside a CI/CD pipeline is thus not recommended as there is generally limited space and time in CI/CD pipelines.
 Writing small and fast unit tests that run automatically inside CI/CD pipelines rather than large integration tests is recommended.
 It is therefore helpful to practice software engineering best practices such as decoupling, since that will lead to more easily testable code.
+Larger integration tests can still be done in CI/CD as long as they don't require more than a few hundred megabytes of space and can complete within say 30 minutes.
+Check the resource limits your CI/CD infrastructure provider (e.g. github or gitlab) imposes on CI/CD pipelines.
+If you expect your tests to require more time and space than the CI/CD platform of you choice allows, consider alternative approaches such as [blue/green deployments](https://en.wikipedia.org/wiki/Blue%E2%80%93green_deployment).

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -94,6 +94,16 @@ It also enables the developer to run unit testing in an automated way to discove
 CICD relies on version control.
 Workflows are usually triggered by events, such as merging to the main branch happening on the verson control repository.
 
+# Docker Containers
+
+Nowadays software is often distributed or deployed using containers.
+These containers contain every dependency an application needs and can run anywhere.
+This is especially useful in applications that run as a service on a cloud provider such as Google or Amazon Web Services where it is not known before hand where an application will run.
+These containers are light weight operating system images in which the application is stored including everything it needs.
+To build these container images, CI/CD is extremely useful as it can be automated as explained below in the section explaining pipelines and workflows.
+Running applications in containers tends to enforce decoupling from external dependencies and communicate to external services through well defined and stable interfaces.
+Building and distributing containers is generally done using [docker](https://www.docker.com) but there are others such as [podman](https://podman.io/)
+
 # Pipelines or workflows
 
 > A CI/CD pipeline is an automated process utilized by software development teams to streamline the creation, testing and deployment of applications. -- [gitlab.com][6]
@@ -470,3 +480,11 @@ A small graph is shown and at the bottom "release-dists" link is provided.
 Click on that to download the package.
 
 That's it! Package published!
+
+## Considerations
+
+CI/CD pipelines are not very suitable if your tests requires a lot of static data.
+Running large integration tests inside a CI/CD pipeline is thus not recommended as there is generally limited space and time in CI/CD pipelines.
+Writing small and fast unit tests that run automatically inside CI/CD pipelines rather than large integration tests is recommended.
+It is therefore helpful to practice sotware engineering best practices such as decoupling.
+Decoupling enables testable code.


### PR DESCRIPTION
The CI/CD lesson was still missing some material about docker containers. This PR adds this material.