### PR TITLE
Update sandpaper-main.yml to pin ubuntu version

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,10 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+
+    # 2025-01-21: ubuntu-latest is now 24.04 and R is not installed by default in the runner image
+    # pin to 22.04 for now. See Carpentries issue/PR [605](https://github.com/carpentries/sandpaper/issues/605)/[606](https://github.com/carpentries/sandpaper/pull/606)
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
Should fix the problem that `R` is not installed by default on the new image